### PR TITLE
fix bug in hex() CharParser

### DIFF
--- a/src/Combinators.mo
+++ b/src/Combinators.mo
@@ -242,7 +242,7 @@ module {
             sat(func (x : Char) : Bool {
                 '0' <= x and x <= '9' or
                 'a' <= x and x <= 'f' or
-                'A' <= x and x <= 'A';
+                'A' <= x and x <= 'F';
             });
         };
 


### PR DESCRIPTION
#### Fixes 
- Increased the hex range for from `A-A` to `A-F`

